### PR TITLE
피드 페이지, 모달 상세게시글 페이지 좋아요 연동, 모달 모바일사이즈 게시글 내용 및 댓글 추가, 병렬 라우트 모달 하드 라우팅 페이지

### DIFF
--- a/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/CommentForm/commentForm.module.css
+++ b/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/CommentForm/commentForm.module.css
@@ -6,7 +6,7 @@
   display: flex;
 }
 .commentInputContainer > input {
-  flex:1 0 auto;
+  flex:1 1 auto;
   border: none;
   padding: 0 8px;
   outline: none;

--- a/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/LikeBtn/index.tsx
+++ b/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/LikeBtn/index.tsx
@@ -43,9 +43,6 @@ const LikeBtn = ({ postId }: LikeBtnProps) => {
       }
       return { previousLike }
     },
-    onSuccess: (data) => {
-      console.log(data)
-    },
     onError: (
       error: Error,
       variables: MutateLikeVariables,

--- a/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/LikeCount/index.tsx
+++ b/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/LikeCount/index.tsx
@@ -13,7 +13,11 @@ interface Like {
 const LikeCount = ({ postId }: LikeCountProps) => {
   const { data } = useQuery<Like>({ queryKey: ['like', postId] })
 
-  return <span className={style.likeCount}>{`좋아요 ${data?.count}개`}</span>
+  return (
+    <span className={style.likeCount}>{`좋아요 ${
+      data ? data.count : 0
+    }개`}</span>
+  )
 }
 
 export default LikeCount

--- a/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/Post/index.tsx
+++ b/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/Post/index.tsx
@@ -12,7 +12,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useFeedService } from '@/app/_services/feedService'
 
 interface PostProps {
-  postId: string
+  postId: number
 }
 
 const Post = ({ postId }: PostProps) => {
@@ -20,6 +20,7 @@ const Post = ({ postId }: PostProps) => {
   const { data, isFetching, isSuccess } = useQuery({
     queryKey: ['hydrate-postDetail', postId],
     queryFn: () => feedService.getPostDetail(postId),
+    staleTime: 0,
   })
 
   if (isFetching) return <p>...로딩중</p>

--- a/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/PostContent/postContent.module.css
+++ b/frontend/app/(route)/(main)/@modal/(...)post/[postId]/components/PostContent/postContent.module.css
@@ -1,6 +1,14 @@
 .postContentContainer {
-  display: none;
+  display: block;
   margin-bottom: 8px;
+  height: 70px;
+  padding: 8px;
+  overflow-y: auto;
+  -ms-overflow-style: none; /* 인터넷 익스플로러 */
+  scrollbar-width: none; /* 파이어폭스 */
+}
+.postContentContainer::-webkit-scrollbar {
+  display: none;
 }
 .postContent {
   margin-bottom: 8px;
@@ -17,13 +25,6 @@
 
 @media (min-width:736px) {
   .postContentContainer {
-    display: block;
     flex: 1 1 auto;
-    overflow-y: auto;
-    -ms-overflow-style: none; /* 인터넷 익스플로러 */
-    scrollbar-width: none; /* 파이어폭스 */
-  }
-  .postContentContainer::-webkit-scrollbar {
-    display: none;
   }
 }

--- a/frontend/app/(route)/(main)/@modal/(...)post/[postId]/page.tsx
+++ b/frontend/app/(route)/(main)/@modal/(...)post/[postId]/page.tsx
@@ -12,7 +12,7 @@ const getCookie = async (key: string) => {
   return cookies().get(key)?.value ?? ''
 }
 const getPostDetail = async (
-  post_id: string,
+  post_id: number,
 ): Promise<PostDetailApiResponse> => {
   const accessToken = await getCookie('accessToken')
   const Url = `${BASE_URL}/api/v1/post/${post_id}`
@@ -20,9 +20,7 @@ const getPostDetail = async (
   const response = await fetch(Url, {
     method: 'GET',
     credentials: 'include',
-    next: {
-      revalidate: 30,
-    },
+    cache: 'no-store',
     headers: {
       Cookie: `accessToken=${accessToken}`,
     },
@@ -30,22 +28,24 @@ const getPostDetail = async (
   if (!response.ok) {
     throw new Error('오류가 발생하였습니다.')
   }
-  console.log(response.status)
-  return await response.json()
+  const data = await response.json()
+  console.log(data)
+  return data
 }
 
 const page = async ({ params }: { params: { postId: string } }) => {
+  const intPostId = parseInt(params.postId)
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['hydrate-postDetail', params.postId],
-    queryFn: () => getPostDetail(params.postId),
+    queryKey: ['hydrate-postDetail', intPostId],
+    queryFn: () => getPostDetail(intPostId),
   })
   const dehydratedState = dehydrate(queryClient)
 
   return (
     <Hydrate state={dehydratedState}>
-      <Modal visible={true}>
-        <Post postId={params.postId} />
+      <Modal>
+        <Post postId={intPostId} />
       </Modal>
     </Hydrate>
   )

--- a/frontend/app/(route)/(main)/@modal/default.tsx
+++ b/frontend/app/(route)/(main)/@modal/default.tsx
@@ -1,7 +1,5 @@
-import React from 'react'
-
 const index = () => {
-  return <></>
+  return null
 }
 
 export default index

--- a/frontend/app/(route)/(main)/explore/_components/Feed/index.tsx
+++ b/frontend/app/(route)/(main)/explore/_components/Feed/index.tsx
@@ -12,6 +12,7 @@ interface FeedItem {
   images: string[]
   like: Like
   nickname: string
+  writerThumnail: string
   postId: number
 }
 interface Like {
@@ -24,14 +25,14 @@ interface FeedProps {
 }
 
 const Feed = ({
-  feed: { nickname, images, createdAt, like, postId },
+  feed: { nickname, images, createdAt, like, postId, writerThumnail },
 }: FeedProps) => {
   const queryClient = useQueryClient()
   queryClient.setQueryData(['like', postId], like)
 
   return (
     <li className={style.main_wrapper}>
-      <FeedHeader nickname={nickname} />
+      <FeedHeader writerThumnail={writerThumnail} nickname={nickname} />
       <FeedBody images={images} />
       <FeedBottomMenu createdAt={createdAt} postId={postId} />
     </li>

--- a/frontend/app/(route)/(main)/explore/_components/FeedHeader/feedHeader.module.css
+++ b/frontend/app/(route)/(main)/explore/_components/FeedHeader/feedHeader.module.css
@@ -1,9 +1,13 @@
-.header_wrapper {
+.headerContainer {
   display: flex;
   padding: 12px;
+  align-items: center;
 }
-.header_link {
-  display: inline-block;
+.headerWrapper {
+  display: flex;
+}
+.headerProfileLink {
+  display: flex;
   margin-right: 8px;
   font-size: 14px;
 }
@@ -11,7 +15,7 @@
   display: flex;
   align-items: center;
 }
-.writer_info_img {
+.writerThumnailImg {
   border-radius: 100%;
   width: 25px;
   height: 25px;

--- a/frontend/app/(route)/(main)/explore/_components/FeedHeader/index.tsx
+++ b/frontend/app/(route)/(main)/explore/_components/FeedHeader/index.tsx
@@ -4,19 +4,20 @@ import Link from 'next/link'
 
 interface FeedHeaderProps {
   nickname: string
+  writerThumnail: string
 }
-const FeedHeader = ({ nickname }: FeedHeaderProps) => {
+const FeedHeader = ({ nickname, writerThumnail }: FeedHeaderProps) => {
   return (
-    <section className={style.header_wrapper}>
-      <div className={style.writer_info_wrapper}>
-        <Link href={`/profile/${nickname}`} className={style.header_link}>
-          <div className={style.writer_info_img}></div>
+    <header className={style.headerContainer}>
+      <div className={style.headerWrapper}>
+        <Link href={`/profile/${nickname}`} className={style.headerProfileLink}>
+          <img src={writerThumnail} className={style.writerThumnailImg} />
         </Link>
-        <Link href={`/profile/${nickname}`} className={style.header_link}>
+        <Link href={`/profile/${nickname}`} className={style.headerProfileLink}>
           {nickname}
         </Link>
       </div>
-    </section>
+    </header>
   )
 }
 

--- a/frontend/app/(route)/(main)/explore/_components/FeedList/index.tsx
+++ b/frontend/app/(route)/(main)/explore/_components/FeedList/index.tsx
@@ -2,9 +2,9 @@
 import React, { useRef } from 'react'
 import Feed from '../Feed'
 import { useInfiniteQuery } from '@tanstack/react-query'
+import useSearchService from '@/app/_services/searchService'
 import { useObserver } from '@/app/_hooks/useUserObserver'
 import { FEED_SIZE } from '@/app/_utils/constants'
-import useGuestService from '@/app/_services/guestService'
 
 interface FeedItem {
   createdAt: Date
@@ -21,13 +21,13 @@ interface Like {
 }
 
 const FeedList = () => {
-  const guestService = useGuestService()
+  const searchService = useSearchService()
   const bottom = useRef<HTMLDivElement | null>(null)
   const { data, error, status, fetchNextPage, isFetchingNextPage } =
     useInfiniteQuery({
       queryKey: ['hydrate-feeds'],
       queryFn: ({ pageParam }) =>
-        guestService.getRecentList(pageParam, FEED_SIZE),
+        searchService.getFeedList(pageParam, FEED_SIZE),
       initialPageParam: 0,
       getNextPageParam: (lastPage, allPages) => {
         if (lastPage.length < FEED_SIZE) {

--- a/frontend/app/(route)/(main)/explore/page.tsx
+++ b/frontend/app/(route)/(main)/explore/page.tsx
@@ -20,6 +20,7 @@ const getAllList = async (page = 0, limit = 3): Promise<FeedItem> => {
   })
   const response = await fetch(`${BASE_URL}/api/v1/guest/search?` + param, {
     credentials: 'include',
+    cache: 'no-store',
     headers: {
       Cookie: `accessToken=${accessToken}`,
     },

--- a/frontend/app/(route)/(main)/feed/[userId]/_components/Feed/index.tsx
+++ b/frontend/app/(route)/(main)/feed/[userId]/_components/Feed/index.tsx
@@ -12,6 +12,7 @@ interface FeedItem {
   images: string[]
   like: Like
   nickname: string
+  writerThumnail: string
   postId: number
 }
 interface Like {
@@ -24,14 +25,14 @@ interface FeedProps {
 }
 
 const Feed = ({
-  feed: { nickname, images, createdAt, like, postId },
+  feed: { nickname, images, createdAt, like, postId, writerThumnail },
 }: FeedProps) => {
   const queryClient = useQueryClient()
   queryClient.setQueryData(['like', postId], like)
 
   return (
     <li className={style.main_wrapper}>
-      <FeedHeader nickname={nickname} />
+      <FeedHeader writerThumnail={writerThumnail} nickname={nickname} />
       <FeedBody images={images} />
       <FeedBottomMenu createdAt={createdAt} postId={postId} />
     </li>

--- a/frontend/app/(route)/(main)/feed/[userId]/_components/FeedHeader/feedHeader.module.css
+++ b/frontend/app/(route)/(main)/feed/[userId]/_components/FeedHeader/feedHeader.module.css
@@ -1,9 +1,13 @@
-.header_wrapper {
+.headerContainer {
   display: flex;
   padding: 12px;
+  align-items: center;
 }
-.header_link {
-  display: inline-block;
+.headerWrapper {
+  display: flex;
+}
+.headerProfileLink {
+  display: flex;
   margin-right: 8px;
   font-size: 14px;
 }
@@ -11,7 +15,7 @@
   display: flex;
   align-items: center;
 }
-.writer_info_img {
+.writerThumnailImg {
   border-radius: 100%;
   width: 25px;
   height: 25px;

--- a/frontend/app/(route)/(main)/feed/[userId]/_components/FeedHeader/index.tsx
+++ b/frontend/app/(route)/(main)/feed/[userId]/_components/FeedHeader/index.tsx
@@ -4,19 +4,20 @@ import Link from 'next/link'
 
 interface FeedHeaderProps {
   nickname: string
+  writerThumnail: string
 }
-const FeedHeader = ({ nickname }: FeedHeaderProps) => {
+const FeedHeader = ({ nickname, writerThumnail }: FeedHeaderProps) => {
   return (
-    <section className={style.header_wrapper}>
-      <div className={style.writer_info_wrapper}>
-        <Link href={`/profile/${nickname}`} className={style.header_link}>
-          <div className={style.writer_info_img}></div>
+    <header className={style.headerContainer}>
+      <div className={style.headerWrapper}>
+        <Link href={`/profile/${nickname}`} className={style.headerProfileLink}>
+          <img src={writerThumnail} className={style.writerThumnailImg} />
         </Link>
-        <Link href={`/profile/${nickname}`} className={style.header_link}>
+        <Link href={`/profile/${nickname}`} className={style.headerProfileLink}>
           {nickname}
         </Link>
       </div>
-    </section>
+    </header>
   )
 }
 

--- a/frontend/app/(route)/(main)/feed/[userId]/page.tsx
+++ b/frontend/app/(route)/(main)/feed/[userId]/page.tsx
@@ -20,6 +20,7 @@ const getAllList = async (page = 0, limit = 3): Promise<FeedItem> => {
   })
   const response = await fetch(`${BASE_URL}/api/v1/search/main?` + param, {
     credentials: 'include',
+    cache: 'no-store',
     headers: {
       Cookie: `accessToken=${accessToken}`,
     },
@@ -32,7 +33,6 @@ const getAllList = async (page = 0, limit = 3): Promise<FeedItem> => {
           createdAt: new Date(feed.createdAt),
         }
       })
-      console.log(result)
       return result
     })
   return response

--- a/frontend/app/(route)/(main)/post/[postId]/components/BookmarkBtn/bookmarkBtn.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/BookmarkBtn/bookmarkBtn.module.css
@@ -1,0 +1,11 @@
+.menuBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+}
+.iconBtn {
+  width: 24px;
+  height: 24px;
+  stroke-width: 0.8px !important;
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/BookmarkBtn/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/BookmarkBtn/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import style from './bookmarkBtn.module.css'
+import { CiBookmark } from 'react-icons/ci'
+
+const BookmarkBtn = () => {
+  return (
+    <button className={style.menuBtn}>
+      <CiBookmark className={style.iconBtn} />
+    </button>
+  )
+}
+
+export default BookmarkBtn

--- a/frontend/app/(route)/(main)/post/[postId]/components/Comment/comment.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/Comment/comment.module.css
@@ -1,0 +1,28 @@
+.commentContainer {
+  display: flex;
+  margin-bottom: 8px;
+}
+.writerThumnailContainer {
+  margin-right: 4px;
+}
+.writerThumnailWrapper {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+}
+.writerThumnailWrapper > img {
+  width: 100%;
+  height: 100%;
+  border-radius: 9999px;
+}
+.commentInfoContainer {
+  display: flex;
+}
+.commentInfoContainer > span {
+  font-size: 12px;
+  font-weight: 300;
+  margin-right: 4px;
+}
+.commentInfoContainer > p {
+  font-size: 12px;
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/Comment/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/Comment/index.tsx
@@ -1,0 +1,30 @@
+'use client'
+import React from 'react'
+import style from './comment.module.css'
+
+interface CommentProps {
+  comment: CommentInfo
+}
+interface CommentInfo {
+  comment: string
+  nickname: string
+  thumnail: string
+}
+
+const Comment = ({ comment }: CommentProps) => {
+  return (
+    <li className={style.commentContainer}>
+      <div className={style.writerThumnailContainer}>
+        <div className={style.writerThumnailWrapper}>
+          <img src={comment.thumnail} />
+        </div>
+      </div>
+      <div className={style.commentInfoContainer}>
+        <span>{comment.nickname}</span>
+        <p>{comment.comment}</p>
+      </div>
+    </li>
+  )
+}
+
+export default Comment

--- a/frontend/app/(route)/(main)/post/[postId]/components/CommentForm/commentForm.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/CommentForm/commentForm.module.css
@@ -1,0 +1,27 @@
+.commentForm {
+  padding: 12px 0;
+  border-top: 1px solid #ccc;
+}
+.commentInputContainer {
+  display: flex;
+}
+.commentInputContainer > input {
+  flex:1 0 auto;
+  border: none;
+  padding: 0 8px;
+  outline: none;
+}
+.commentInputContainer > button {
+  font-size: 12px;
+  background-color: orange;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+@media (min-width:400px) {
+  .commentForm {
+    padding: 0;
+    padding-top: 12px;
+  }
+
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/CommentForm/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/CommentForm/index.tsx
@@ -1,0 +1,65 @@
+'use client'
+import React from 'react'
+import style from './commentForm.module.css'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import useCommentService, {
+  CommentUploadApiResponse,
+} from '@/app/_services/commentService'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+interface CommentFormReturn {
+  comment: string
+}
+interface CommentMutationInput {
+  postId: number
+  comment: string
+}
+
+const CommentForm = ({ postId }: { postId: number }) => {
+  const { register, handleSubmit, reset } = useForm<CommentFormReturn>()
+  const queryClient = useQueryClient()
+  const commentService = useCommentService()
+  const commentMutation = useMutation<
+    CommentUploadApiResponse,
+    Error,
+    CommentMutationInput
+  >({
+    mutationFn: ({ comment, postId }) => commentService.upload(comment, postId),
+  })
+
+  const handleUploadComment: SubmitHandler<CommentFormReturn> = ({
+    comment,
+  }) => {
+    commentMutation.mutate(
+      { comment, postId },
+      {
+        onSuccess: () => {
+          reset()
+          queryClient.invalidateQueries({
+            queryKey: ['hydrate-postDetail', postId],
+          })
+        },
+        onError: (error) => {
+          console.log(error)
+        },
+      },
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(handleUploadComment)}
+      className={style.commentForm}
+    >
+      <div className={style.commentInputContainer}>
+        <input
+          {...register('comment', { required: true })}
+          placeholder="댓글 달기"
+        />
+        <button type="submit">게시</button>
+      </div>
+    </form>
+  )
+}
+
+export default CommentForm

--- a/frontend/app/(route)/(main)/post/[postId]/components/LikeBtn/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/LikeBtn/index.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import style from './likeBtn.module.css'
+import cn from 'classnames'
+import { TbHeart } from 'react-icons/tb'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useFeedService } from '@/app/_services/feedService'
+
+interface LikeBtnProps {
+  postId: number
+}
+interface Like {
+  count: number
+  isLike: boolean
+}
+interface MutateLikeVariables {
+  postId: number
+}
+
+const LikeBtn = ({ postId }: LikeBtnProps) => {
+  const feedService = useFeedService()
+  const queryClient = useQueryClient()
+  const { data } = useQuery<Like>({ queryKey: ['like', postId] })
+  const likeMutation = useMutation<
+    Like,
+    Error,
+    MutateLikeVariables,
+    { previousLike: Like | undefined }
+  >({
+    mutationFn: ({ postId }) => feedService.updateLike(postId),
+    onMutate: async ({ postId }) => {
+      await queryClient.cancelQueries({ queryKey: ['like', postId] })
+      const previousLike = queryClient.getQueryData<Like>(['like', postId])
+
+      if (previousLike) {
+        const nextLike = {
+          count: previousLike.isLike
+            ? previousLike.count - 1
+            : previousLike.count + 1,
+          isLike: !previousLike.isLike,
+        }
+
+        queryClient.setQueryData<Like>(['like', postId], nextLike)
+      }
+      return { previousLike }
+    },
+    onError: (
+      error: Error,
+      variables: MutateLikeVariables,
+      context?: { previousLike: Like | undefined },
+    ) => {
+      if (context?.previousLike) {
+        queryClient.setQueryData<Like>(['like', postId], context.previousLike)
+      }
+      console.log(error)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['like'] })
+    },
+  })
+
+  const HandleClickLikeBtn = () => {
+    likeMutation.mutate({ postId })
+  }
+
+  return (
+    <button className={style.menuBtn} onClick={HandleClickLikeBtn}>
+      <TbHeart
+        className={cn(style.btnIcon, style.likeWBtn, {
+          [style.likeBtnActive]: data?.isLike,
+        })}
+      />
+    </button>
+  )
+}
+
+export default LikeBtn

--- a/frontend/app/(route)/(main)/post/[postId]/components/LikeBtn/likeBtn.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/LikeBtn/likeBtn.module.css
@@ -1,0 +1,23 @@
+.menuBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+}
+.btnIcon {
+  width: 100%;
+  height: 100%;
+  stroke-width: 0.8px !important;
+}
+.likeBtn {
+  transition: all 0.25s ease-in-out;
+}
+.likeBtn:hover {
+  color: red;
+}
+.likeBtnActive {
+  color:red;
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/LikeCount/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/LikeCount/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import style from './likeCount.module.css'
+import { useQuery } from '@tanstack/react-query'
+
+interface LikeCountProps {
+  postId: number
+}
+interface Like {
+  count: number
+  isLike: boolean
+}
+
+const LikeCount = ({ postId }: LikeCountProps) => {
+  const { data } = useQuery<Like>({ queryKey: ['like', postId] })
+
+  return (
+    <span className={style.likeCount}>{`좋아요 ${
+      data ? data.count : 0
+    }개`}</span>
+  )
+}
+
+export default LikeCount

--- a/frontend/app/(route)/(main)/post/[postId]/components/LikeCount/likeCount.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/LikeCount/likeCount.module.css
@@ -1,0 +1,3 @@
+.likeCount {
+  font-size: 12px;
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/Post/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/Post/index.tsx
@@ -1,0 +1,70 @@
+'use client'
+import React, { useEffect } from 'react'
+import style from './post.module.css'
+import PostMedia from '../PostMedia'
+import LikeBtn from '../LikeBtn'
+import BookmarkBtn from '../BookmarkBtn'
+import LikeCount from '../LikeCount'
+import CommentForm from '../CommentForm'
+import WriterInfoHeader from '../WriterInfoHeader'
+import PostContent from '../PostContent'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useFeedService } from '@/app/_services/feedService'
+
+interface PostProps {
+  postId: number
+}
+
+const Post = ({ postId }: PostProps) => {
+  const feedService = useFeedService()
+  const queryClient = useQueryClient()
+  const { data, isFetching, isSuccess, isFetched } = useQuery({
+    queryKey: ['hydrate-postDetail', postId],
+    queryFn: () => feedService.getPostDetail(postId),
+  })
+
+  useEffect(() => {
+    queryClient.setQueryData(['like', postId], data?.like)
+  }, [isFetched])
+
+  if (isFetching) return <p>...로딩중</p>
+  if (isSuccess) {
+    return (
+      <div className={style.postWrapper}>
+        <WriterInfoHeader
+          writerThumnail={data?.writerThumnail}
+          nickname={data?.nickname}
+        />
+        <PostMedia images={data?.images} />
+        <div className={style.noneMediaContainer}>
+          <header className={style.userInfoContainer}>
+            <div className={style.writerThumnailWrapper}>
+              <img src={data.writerThumnail} />
+            </div>
+            <div>{data.nickname}</div>
+          </header>
+          <PostContent
+            content={data?.content}
+            hashtags={data?.hashtags}
+            comments={data.comments}
+          />
+          <div className={style.userInteractContainer}>
+            <div className={style.userInteractBtnsContainer}>
+              <LikeBtn postId={data?.postId} />
+              <BookmarkBtn />
+            </div>
+            <div className={style.likeCountContainer}>
+              <LikeCount postId={data?.postId} />
+            </div>
+            <div className={style.createdAtContainer}>
+              <span>{`${data?.createdAt}`}</span>
+            </div>
+            <CommentForm postId={data?.postId} />
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Post

--- a/frontend/app/(route)/(main)/post/[postId]/components/Post/post.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/Post/post.module.css
@@ -1,0 +1,71 @@
+.postWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+.userInfoContainer {
+  display: none;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.writerThumnailWrapper {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  margin-right: 12px;
+}
+.writerThumnailWrapper > img {
+  width: 100%;
+  height: 100%;
+  border-radius: 9999px;
+}
+.userInteractContainer {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+}
+.userInteractBtnsContainer {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.userInteractBtnsContainer > div {
+  display: flex;
+}
+.likeCountContainer {
+  margin-bottom: 8px;
+}
+.likeCountContainer > span {
+  font-size: 16px;
+  font-weight: bold;
+}
+.createdAtContainer {
+  margin-bottom: 8px;
+}
+.createdAtContainer > span {
+  font-size: 12px;
+  color:#ccc;
+}
+
+@media (min-width:600px) {
+  .postWrapper {
+    flex-direction: row;
+    height: 600px;
+  }
+  .noneMediaContainer {
+    flex: 1.5 1 200px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 12px;
+  }
+  .userInfoContainer {
+    display: flex;
+  }
+  .userInteractContainer {
+    flex: 0 0 auto;
+    width: 100%;
+    padding: 0;
+  }
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/PostContent/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/PostContent/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import style from './postContent.module.css'
+import Link from 'next/link'
+import Comment from '../Comment'
+
+interface PostContentProps {
+  content: string
+  hashtags: string[]
+  comments: CommentInfo[]
+}
+interface CommentInfo {
+  comment: string
+  nickname: string
+  thumnail: string
+}
+
+const PostContent = ({ content, hashtags, comments }: PostContentProps) => {
+  return (
+    <div className={style.postContentContainer}>
+      <p className={style.postContent}>{content}</p>
+      <ul className={style.hashtagList}>
+        {hashtags.map((hashtag, idx) => (
+          <Link
+            key={hashtag + idx}
+            href={`/search?hashtag=${hashtag}`}
+            className={style.hashtag}
+          >{`#${hashtag}`}</Link>
+        ))}
+      </ul>
+      <div>
+        {comments.map((comment, idx) => (
+          <Comment key={comment.nickname + idx} comment={comment} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default PostContent

--- a/frontend/app/(route)/(main)/post/[postId]/components/PostContent/postContent.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/PostContent/postContent.module.css
@@ -1,0 +1,29 @@
+.postContentContainer {
+  display: block;
+  margin-bottom: 8px;
+  padding: 8px;
+}
+.postContent {
+  margin-bottom: 8px;
+}
+.hashtagList {
+  margin-bottom: 8px;
+}
+.hashtag {
+  margin-right: 4px;
+}
+.hashtag:hover {
+  text-decoration: underline;
+}
+
+@media (min-width:600px) {
+  .postContentContainer {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    -ms-overflow-style: none; /* 인터넷 익스플로러 */
+    scrollbar-width: none; /* 파이어폭스 */
+  }
+  .postContentContainer::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/PostMedia/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/PostMedia/index.tsx
@@ -1,0 +1,30 @@
+'use client'
+import React from 'react'
+import style from './postMedia.module.css'
+import { Pagination, Navigation } from 'swiper/modules'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import 'swiper/css'
+import 'swiper/css/navigation'
+import 'swiper/css/pagination'
+
+const PostMedia = ({ images }: { images: string[] }) => {
+  return (
+    <div className={style.swiperContainer}>
+      <Swiper
+        modules={[Pagination, Navigation]}
+        slidesPerView={1}
+        navigation
+        pagination={{ clickable: true }}
+        className={style.swiper}
+      >
+        {images?.map((img: string) => (
+          <SwiperSlide key={img} className={style.slideItem}>
+            <img className={style.slideImg} src={img} alt="이미지" />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  )
+}
+
+export default PostMedia

--- a/frontend/app/(route)/(main)/post/[postId]/components/PostMedia/postMedia.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/PostMedia/postMedia.module.css
@@ -1,0 +1,36 @@
+.swiperContainer {
+  width: 100%;
+  margin-bottom: 12px;
+}
+.swiper{
+  width:100%;
+  height: 100%;
+}
+.slideItem {
+  position: relative;
+  width: 100%;
+  height: 340px;
+  background-color: black;
+}
+.slideImg {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 100%;
+  object-fit:cover
+}
+
+@media (min-width:600px) {
+  .swiperContainer {
+    width: 0;
+    flex: 2 0 auto;
+    height: 100%;
+  }
+  .slideItem {
+    height: 100%;
+  }
+  .slideImg {
+    top: 50%;
+    left: 0;
+  }
+}

--- a/frontend/app/(route)/(main)/post/[postId]/components/WriterInfoHeader/index.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/components/WriterInfoHeader/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import style from './writerInfoHeader.module.css'
+
+interface WriterInfoHeaderProps {
+  writerThumnail: string
+  nickname: string
+}
+
+const WriterInfoHeader = ({
+  writerThumnail,
+  nickname,
+}: WriterInfoHeaderProps) => {
+  return (
+    <header className={style.userInfoContainer}>
+      <div className={style.writerThumnailWrapper}>
+        <img src={writerThumnail} />
+      </div>
+      <div>{nickname}</div>
+    </header>
+  )
+}
+
+export default WriterInfoHeader

--- a/frontend/app/(route)/(main)/post/[postId]/components/WriterInfoHeader/writerInfoHeader.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/components/WriterInfoHeader/writerInfoHeader.module.css
@@ -1,0 +1,22 @@
+.userInfoContainer {
+  display: flex;
+  padding: 12px;
+  align-items: center;
+}
+.writerThumnailWrapper {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  margin-right: 12px;
+}
+.writerThumnailWrapper > img {
+  width: 100%;
+  height: 100%;
+  border-radius: 9999px;
+}
+
+@media (min-width:600px) {
+  .userInfoContainer {
+    display: none;
+  }
+}

--- a/frontend/app/(route)/(main)/post/[postId]/page.module.css
+++ b/frontend/app/(route)/(main)/post/[postId]/page.module.css
@@ -1,0 +1,11 @@
+.postDetailPageContainer {
+  width: 100%;
+  margin-top: 44px;
+  margin-bottom: 64px;
+}
+
+@media (min-width:1001px) {
+  .postDetailPageContainer {
+    margin-top: 64px;
+  }
+}

--- a/frontend/app/(route)/(main)/post/[postId]/page.tsx
+++ b/frontend/app/(route)/(main)/post/[postId]/page.tsx
@@ -1,7 +1,52 @@
 import React from 'react'
+import style from './page.module.css'
+import Post from './components/Post'
+import { BASE_URL } from '@/app/_utils/constants'
+import { cookies } from 'next/headers'
+import { getQueryClient } from '@/app/getQueryClient'
+import { dehydrate } from '@tanstack/react-query'
+import Hydrate from '@/app/_utils/hydrate.client'
+import { PostDetailApiResponse } from '@/app/_services/feedService'
 
-const page = () => {
-  return <div>page</div>
+const getCookie = async (key: string) => {
+  return cookies().get(key)?.value ?? ''
+}
+const getPostDetail = async (
+  post_id: number,
+): Promise<PostDetailApiResponse> => {
+  const accessToken = await getCookie('accessToken')
+  const Url = `${BASE_URL}/api/v1/post/${post_id}`
+
+  const response = await fetch(Url, {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-cache',
+    headers: {
+      Cookie: `accessToken=${accessToken}`,
+    },
+  })
+  if (!response.ok) {
+    throw new Error('오류가 발생하였습니다.')
+  }
+  return await response.json()
+}
+
+const page = async ({ params }: { params: { postId: string } }) => {
+  const intPostId = parseInt(params.postId)
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: ['hydrate-postDetail', intPostId],
+    queryFn: () => getPostDetail(intPostId),
+  })
+  const dehydratedState = dehydrate(queryClient)
+
+  return (
+    <Hydrate state={dehydratedState}>
+      <div className={style.postDetailPageContainer}>
+        <Post postId={intPostId} />
+      </div>
+    </Hydrate>
+  )
 }
 
 export default page

--- a/frontend/app/_common/BottomMenu/bottomMenu.module.css
+++ b/frontend/app/_common/BottomMenu/bottomMenu.module.css
@@ -35,7 +35,7 @@
   height: 24px;
 }
 @media (min-width:1001px) {
-  .main_wrapper {
+  .bottomMenuContainer {
     display: none;
   }
 }

--- a/frontend/app/_common/Modal/index.tsx
+++ b/frontend/app/_common/Modal/index.tsx
@@ -1,41 +1,58 @@
 'use client'
-
-import React, { useEffect } from 'react'
+import React, { MouseEventHandler, useCallback, useEffect, useRef } from 'react'
 import style from './modal.module.css'
-// import cn from 'classnames'
 import { useRouter } from 'next/navigation'
 import { useBodyScrollLock } from '@/app/_hooks/useBodyScrollLock'
 
 interface ModalProps {
   children: React.ReactNode
-  visible: boolean
 }
 
-const Modal = ({ children, visible = false }: ModalProps) => {
+const Modal = ({ children }: ModalProps) => {
   const router = useRouter()
+  const overlay = useRef(null)
+  const wrapper = useRef(null)
   const { openScroll, lockScroll } = useBodyScrollLock()
 
+  const onDismiss = useCallback(() => {
+    router.back()
+  }, [router])
+
+  const onClick: MouseEventHandler = useCallback(
+    (e) => {
+      if (e.target === overlay.current || e.target === wrapper.current) {
+        if (onDismiss) onDismiss()
+      }
+    },
+    [onDismiss, overlay, wrapper],
+  )
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss()
+    },
+    [onDismiss],
+  )
+
   useEffect(() => {
-    if (visible) {
-      lockScroll()
-    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onKeyDown])
+
+  useEffect(() => {
+    lockScroll()
+
     return () => {
       openScroll()
     }
-  }, [visible])
+  }, [])
 
-  // Modal 닫기 함수
-  const closeModal = () => {
-    router.back()
-  }
   return (
-    visible && (
-      <div className={style.modalOverlay} onClick={closeModal}>
-        <div className={style.modal} onClick={(e) => e.stopPropagation()}>
-          {children}
-        </div>
+    <div ref={overlay} className={style.modalOverlay} onClick={onClick}>
+      <div ref={wrapper} className={style.modal}>
+        {children}
       </div>
-    )
+    </div>
   )
 }
 

--- a/frontend/app/_services/feedService.ts
+++ b/frontend/app/_services/feedService.ts
@@ -28,7 +28,7 @@ interface FeedService {
   upload: (form: FormData) => Promise<void>
   registComment: (comment: string) => Promise<void>
   updateLike: (feedId: number) => Promise<Like>
-  getPostDetail: (postId: string) => Promise<PostDetailApiResponse>
+  getPostDetail: (postId: number) => Promise<PostDetailApiResponse>
 }
 
 function useFeedService(): FeedService {


### PR DESCRIPTION
### 반영브랜치
refact/postmodal -> development

피드 페이지, 모달 상세게시글 페이지 좋아요 연동, 모달 모바일사이즈 게시글 내용 및 댓글 추가, 병렬 라우트 모달 하드 라우팅 페이지

![image](https://github.com/03hoho03/whatMeow/assets/122659293/59af452b-b028-4e3e-9ae6-d7514ccd55e4)
모달 게시글 내용 및 댓글 추가
좋아요 수 상태 연동

![image](https://github.com/03hoho03/whatMeow/assets/122659293/669f040b-d0eb-4fb9-96d1-4ca9654c3b27)
post/{postId} 하드 라우팅 시 페이지