### PR TITLE
Fix: 좋아요 클릭 시 Version 함께 제공

### DIFF
--- a/backend/app/api/v2/application/apply_like_get_post.py
+++ b/backend/app/api/v2/application/apply_like_get_post.py
@@ -4,6 +4,6 @@ from ..post.utils import databases as postdb
 
 async def apply_like_get_post(userId, postId, version, db):
     stat = await likedb.apply_like(userId, postId, db)
-    likeCount = await postdb.update_version_likes(postId, stat, version, db)
+    likeCount, version = await postdb.update_version_likes(postId, stat, version, db)
 
-    return stat, likeCount
+    return stat, likeCount, version

--- a/backend/app/api/v2/comment/controller.py
+++ b/backend/app/api/v2/comment/controller.py
@@ -1,11 +1,17 @@
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.orm.session import Session
+from typing import List
 
 from app.database import get_db
 from . import schema
-from .service import writeService
+from .service import writeService, readService
 
 router = APIRouter(tags=["CommentV2"])
+
+
+@router.get("/{postId}", status_code=status.HTTP_200_OK, response_model=List[schema.CommentReturn])
+async def get(postId: int, db: Session = Depends(get_db)):
+    return await readService.lookupComment(postId, db)
 
 
 @router.post("/{postId}", status_code=status.HTTP_201_CREATED, response_model=schema.CommentReturn)

--- a/backend/app/api/v2/comment/service/readService.py
+++ b/backend/app/api/v2/comment/service/readService.py
@@ -1,0 +1,6 @@
+from ..utils import databases
+
+async def lookupComment(postId, db):
+    comments = databases.find_commets_by_post_id(postId, db)
+  
+    return comments

--- a/backend/app/api/v2/like/service/writeService.py
+++ b/backend/app/api/v2/like/service/writeService.py
@@ -2,7 +2,7 @@ from ...application import apply_like_get_post
 
 
 async def applyLike(userId, postId, data, db):
-    stat, likeCount = await apply_like_get_post.apply_like_get_post(userId, postId, data.version, db)
+    stat, likeCount, version = await apply_like_get_post.apply_like_get_post(userId, postId, data.version, db)
     db.commit()
 
-    return {"like": {"isLike": stat, "count": likeCount}}
+    return {"like": {"isLike": stat, "count": likeCount}, "version": version}

--- a/backend/app/api/v2/post/utils/databases.py
+++ b/backend/app/api/v2/post/utils/databases.py
@@ -69,7 +69,7 @@ async def update_version_likes(postId, stat, version, db):
         else:
             post.likeCount -= 1
 
-        return post.likeCount
+        return post.likeCount, post.version
     else:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Post Version Error. Try Again")
 


### PR DESCRIPTION
좋아요 클릭 시에 Version을 제공해주지 않아, 프론트 쪽에서 다시 버튼을 눌렀을 때
Version이 최신화되어 있지 않을 상태이기 때문에 에러가 발생함. 이를 수정해주기 위해 Version도 함께 반환해주도록 수정