### PR TITLE
Refactor: 이미지 업로드 버튼 범위 확장

### DIFF
--- a/frontend/app/(route)/(main)/feed/writer/_components/ImageUpload/imageUpload.module.css
+++ b/frontend/app/(route)/(main)/feed/writer/_components/ImageUpload/imageUpload.module.css
@@ -12,12 +12,13 @@
   width: 90px;
   height: 90px;
 }
+.upload_button:hover {
+  cursor: pointer;
+}
 .upload_input {
   width: 0;
   height: 0;
 }
-.upload_label {
-} 
 .upload_img {
   width: 28px;
   height: 28px;

--- a/frontend/app/(route)/(main)/feed/writer/_components/ImageUpload/index.tsx
+++ b/frontend/app/(route)/(main)/feed/writer/_components/ImageUpload/index.tsx
@@ -39,7 +39,7 @@ function ImageUpload() {
 
   return (
     <section className={style.main_wrapper}>
-      <div className={style.upload_button}>
+      <label htmlFor="imageUpload" className={style.upload_button}>
         <input
           id="imageUpload"
           accept="image/*,video/*"
@@ -48,14 +48,14 @@ function ImageUpload() {
           className={style.upload_input}
           onChange={HandleChangeFileInput}
         />
-        <label htmlFor="imageUpload" className={style.upload_label}>
+        <div>
           <AiOutlineCamera className={style.upload_img} />
           <p className={style.preview_length_container}>
             <span className={style.preview_length_now}>{fileList.length}</span>
             <span>{`/${MAX_IMAGE_LENGTH}`}</span>
           </p>
-        </label>
-      </div>
+        </div>
+      </label>
       <Swiper swiperContainer={swiperContainer}>
         <ul className={style.preview_ul} ref={swiperContainer}>
           {fileList.map(({ url }, idx) => (


### PR DESCRIPTION
게시글 작성페이지의 이미지 업로드 버튼의 반응 범위를 확장하였다.

![이미지업로드버튼범위확장전](https://github.com/03hoho03/whatMeow/assets/122659293/4ee6918e-9c48-4b55-962f-57e1df34fd75)

기존에는 아이콘과 현재/전체 사진수 만 포함된, padding 부분을 제외한부분에서만 클릭하였을 때 업로드 창이 열렸지만 변경 후에는 전체 레이아웃에 반응하게 하였다